### PR TITLE
Add operations to main menu

### DIFF
--- a/multi-magit.el
+++ b/multi-magit.el
@@ -41,9 +41,13 @@
 (easy-menu-define multi-magit-status-mode-menu multi-magit-status-mode-map
   "Multi-Magit menu"
   '("Multi-Magit"
+    ["Status"            multi-magit-status t]
+    ["Checkout"          multi-magit-checkout t]
+    ["Git command"       multi-magit-git-command t]
+    ["Shell command"     multi-magit-shell-command t]
     ["List repositories" multi-magit-list-repositories t]
     "---"
-    ["Quit" magit-mode-bury-buffer t]
+    ["Quit"    magit-mode-bury-buffer t]
     ["Refresh" multi-magit-status t]))
 
 (defun multi-magit--find-current-section ()

--- a/multi-magit.el
+++ b/multi-magit.el
@@ -41,7 +41,6 @@
 (easy-menu-define multi-magit-status-mode-menu multi-magit-status-mode-map
   "Multi-Magit menu"
   '("Multi-Magit"
-    ["Status"            multi-magit-status t]
     ["Checkout"          multi-magit-checkout t]
     ["Git command"       multi-magit-git-command t]
     ["Shell command"     multi-magit-shell-command t]


### PR DESCRIPTION
Added the following operations to the main menu bar:
- multi-magit-status
- multi-magit-checkout
- multi-magit-git-command
- multi-magit-shell-command